### PR TITLE
use older js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
-const map = f => source => (start, sink) => {
-  if (start !== 0) return;
-  source(0, (t, d) => {
-    sink(t, t === 1 ? f(d) : d)
-  });
+var map = function map(f) {
+  return function(source) {
+    return function(start, sink) {
+      if (start !== 0) return;
+      source(0, function(t, d) {
+        sink(t, t === 1 ? f(d) : d);
+      });
+    };
+  };
 };
 
 module.exports = map;


### PR DESCRIPTION
in some build environments (such as create-react-app's), es6 code cannot be minified